### PR TITLE
[tests] Modify functest tests when fetching from archive

### DIFF
--- a/tests/test_functest.py
+++ b/tests/test_functest.py
@@ -237,7 +237,8 @@ class TestFunctestBackendArchive(TestCaseBackendArchive):
 
     def setUp(self):
         super().setUp()
-        self.backend = Functest(FUNCTEST_URL, archive=self.archive)
+        self.backend_write_archive = Functest(FUNCTEST_URL, archive=self.archive)
+        self.backend_read_archive = Functest(FUNCTEST_URL, archive=self.archive)
 
     @httpretty.activate
     @unittest.mock.patch('perceval.backends.opnfv.functest.datetime_utcnow')


### PR DESCRIPTION
This patch adds two different backend objects (one fetches data from remote a data source and the other one from an archive) in order to ensure that backend and method params are initialized in the same way independently from which method is called (fetch or fetch_from_archive)