### PR TITLE
[functest] Set category when calling fetch and fetch_from_archive

### DIFF
--- a/perceval/backends/opnfv/functest.py
+++ b/perceval/backends/opnfv/functest.py
@@ -49,7 +49,7 @@ class Functest(Backend):
     :param tag: label used to mark the data
     :param archive: archive to store/retrieve items
     """
-    version = '0.4.1'
+    version = '0.4.2'
 
     CATEGORIES = [CATEGORY_FUNCTEST]
 
@@ -80,9 +80,14 @@ class Functest(Backend):
 
         return items
 
-    def fetch_items(self, **kwargs):
-        """Fetch tests data"""
+    def fetch_items(self, category, **kwargs):
+        """Fetch tests data
 
+        :param category: the category of items to fetch
+        :param kwargs: backend arguments
+
+        :returns: a generator of items
+        """
         from_date = kwargs['from_date']
         to_date = kwargs['to_date']
 


### PR DESCRIPTION
This patch adds to the params of the fetch_items method the category. Thus, it allows to handle fetching operations (fetch and fetch_from_archive) with multiple categories