### PR TITLE
[functest] Change toolkit import

### DIFF
--- a/perceval/backends/opnfv/functest.py
+++ b/perceval/backends/opnfv/functest.py
@@ -22,10 +22,10 @@
 import json
 import logging
 
-from grimoirelab.toolkit.datetime import (datetime_utcnow,
+from grimoirelab_toolkit.datetime import (datetime_utcnow,
                                           datetime_to_utc,
                                           str_to_datetime)
-from grimoirelab.toolkit.uris import urijoin
+from grimoirelab_toolkit.uris import urijoin
 
 from ...backend import (Backend,
                         BackendCommand,


### PR DESCRIPTION
This code replaces the import of grimoirelab toolkit to make the code working with the new package structure of the toolkit.

This PR is related to https://github.com/chaoss/grimoirelab-toolkit/pull/13