### PR TITLE
[functest] Include cateory options in helptext

### DIFF
--- a/perceval/backends/opnfv/functest.py
+++ b/perceval/backends/opnfv/functest.py
@@ -237,11 +237,12 @@ class FunctestCommand(BackendCommand):
 
     BACKEND = Functest
 
-    @staticmethod
-    def setup_cmd_parser():
+    @classmethod
+    def setup_cmd_parser(cls):
         """Returns the Functest argument parser."""
 
-        parser = BackendCommandArgumentParser(from_date=True,
+        parser = BackendCommandArgumentParser(cls.BACKEND.CATEGORIES,
+                                              from_date=True,
                                               to_date=True,
                                               archive=True)
 

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ try:
     import pypandoc
     long_description = pypandoc.convert(readme_md, 'rst')
 except (IOError, ImportError):
-    print("Warning: pypandoc module not found, or pandoc not installed. " +
+    print("Warning: pypandoc module not found, or pandoc not installed. "
           "Using md instead of rst")
     with codecs.open(readme_md, encoding='utf-8') as f:
         long_description = f.read()

--- a/tests/test_functest.py
+++ b/tests/test_functest.py
@@ -328,6 +328,7 @@ class TestFunctestCommand(unittest.TestCase):
 
         parser = FunctestCommand.setup_cmd_parser()
         self.assertIsInstance(parser, BackendCommandArgumentParser)
+        self.assertEqual(parser._categories, Functest.CATEGORIES)
 
         args = ['--from-date', '1970-01-01',
                 '--to-date', '2010-01-01',


### PR DESCRIPTION
Minor update in functest backend to include available category options to the helptext and align it to the parent Backend.
@valeriocos @sduenas please see