### PR TITLE
[functest] Add search fields

### DIFF
--- a/perceval/backends/opnfv/functest.py
+++ b/perceval/backends/opnfv/functest.py
@@ -49,9 +49,12 @@ class Functest(Backend):
     :param tag: label used to mark the data
     :param archive: archive to store/retrieve items
     """
-    version = '0.4.2'
+    version = '0.5.0'
 
     CATEGORIES = [CATEGORY_FUNCTEST]
+    EXTRA_SEARCH_FIELDS = {
+        'project_name': ['project_name']
+    }
 
     def __init__(self, url, tag=None, archive=None):
         origin = url

--- a/tests/test_functest.py
+++ b/tests/test_functest.py
@@ -223,6 +223,20 @@ class TestFunctestBackend(unittest.TestCase):
         # Check requests
         self.assertEqual(len(httpretty.httpretty.latest_requests), 1)
 
+    @httpretty.activate
+    def test_search_fields(self):
+        """Test whether the search_fields is properly set"""
+
+        setup_http_server()
+
+        functest = Functest(FUNCTEST_URL)
+        items = [item for item in functest.fetch()]
+
+        item = items[0]
+        self.assertEqual(functest.metadata_id(item['data']), item['search_fields']['item_id'])
+        self.assertEqual(item['data']['project_name'], 'functest')
+        self.assertEqual(item['data']['project_name'], item['search_fields']['project_name'])
+
     def test_parse_json(self):
         """Test if it parses a JSON stream"""
 


### PR DESCRIPTION
This code extends the Functest backend by including a set of search fields to simplify query operations. The search fields introduced are: `item_id` and `project_name`.

Tests have been added accordingly.
The backend version is set to 0.5.0.