### PR TITLE
[backend] Change signature BackendCommandArgumentParser

### DIFF
--- a/perceval/backends/opnfv/functest.py
+++ b/perceval/backends/opnfv/functest.py
@@ -244,7 +244,7 @@ class FunctestCommand(BackendCommand):
     def setup_cmd_parser(cls):
         """Returns the Functest argument parser."""
 
-        parser = BackendCommandArgumentParser(cls.BACKEND.CATEGORIES,
+        parser = BackendCommandArgumentParser(cls.BACKEND,
                                               from_date=True,
                                               to_date=True,
                                               archive=True)

--- a/tests/test_functest.py
+++ b/tests/test_functest.py
@@ -342,7 +342,7 @@ class TestFunctestCommand(unittest.TestCase):
 
         parser = FunctestCommand.setup_cmd_parser()
         self.assertIsInstance(parser, BackendCommandArgumentParser)
-        self.assertEqual(parser._categories, Functest.CATEGORIES)
+        self.assertEqual(parser._backend, Functest)
 
         args = ['--from-date', '1970-01-01',
                 '--to-date', '2010-01-01',


### PR DESCRIPTION
This code changes the signature of the class `BackendCommandArgumentParser`,
which now accepts as first parameter the backend object instead
its categories. This change is needed to simplify accessing other backend
attributes, beyond the categories.

Functest backend and corresponding tests have been updated.

Signed-off-by: Valerio Cosentino <valcos@bitergia.com>