### PR TITLE
[functest] Support for SSL verification

### DIFF
--- a/perceval/backends/opnfv/functest.py
+++ b/perceval/backends/opnfv/functest.py
@@ -17,6 +17,7 @@
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>
+#     Quan Zhou <quan@bitergia.com>
 #
 
 import json
@@ -48,18 +49,19 @@ class Functest(Backend):
     :param url: Functest URL
     :param tag: label used to mark the data
     :param archive: archive to store/retrieve items
+    :param ssl_verify: enable/disable SSL verification
     """
-    version = '0.5.0'
+    version = '0.6.0'
 
     CATEGORIES = [CATEGORY_FUNCTEST]
     EXTRA_SEARCH_FIELDS = {
         'project_name': ['project_name']
     }
 
-    def __init__(self, url, tag=None, archive=None):
+    def __init__(self, url, tag=None, archive=None, ssl_verify=True):
         origin = url
 
-        super().__init__(origin, tag=tag, archive=archive)
+        super().__init__(origin, tag=tag, archive=archive, ssl_verify=ssl_verify)
         self.url = url
         self.client = None
 
@@ -176,7 +178,7 @@ class Functest(Backend):
     def _init_client(self, from_archive=False):
         """Init client"""
 
-        return FunctestClient(self.url, self.archive, from_archive)
+        return FunctestClient(self.url, self.archive, from_archive, self.ssl_verify)
 
 
 class FunctestClient(HttpClient):
@@ -188,6 +190,7 @@ class FunctestClient(HttpClient):
     :param base_url: URL of the Functest server
     :param archive: an archive to store/read fetched data
     :param from_archive: it tells whether to write/read the archive
+    :param ssl_verify: enable/disable SSL verification
     """
     FUNCTEST_API_PATH = "/api/v1/"
 
@@ -202,9 +205,10 @@ class FunctestClient(HttpClient):
     # Maximum retries per request
     MAX_RETRIES = 3
 
-    def __init__(self, base_url, archive=None, from_archive=False):
+    def __init__(self, base_url, archive=None, from_archive=False, ssl_verify=True):
         super().__init__(base_url, max_retries=FunctestClient.MAX_RETRIES,
-                         archive=archive, from_archive=from_archive)
+                         archive=archive, from_archive=from_archive,
+                         ssl_verify=ssl_verify)
 
     def results(self, from_date, to_date=None):
         """Get test cases results."""
@@ -247,7 +251,8 @@ class FunctestCommand(BackendCommand):
         parser = BackendCommandArgumentParser(cls.BACKEND,
                                               from_date=True,
                                               to_date=True,
-                                              archive=True)
+                                              archive=True,
+                                              ssl_verify=True)
 
         # Required arguments
         parser.parser.add_argument('url',

--- a/tests/test_functest.py
+++ b/tests/test_functest.py
@@ -17,6 +17,7 @@
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>
+#     Quan Zhou <quan@bitergia.com>
 #
 
 import datetime
@@ -87,12 +88,14 @@ class TestFunctestBackend(unittest.TestCase):
         self.assertEqual(functest.origin, FUNCTEST_URL)
         self.assertEqual(functest.tag, 'test')
         self.assertIsNone(functest.client)
+        self.assertTrue(functest.ssl_verify)
 
         # When tag is empty or None it will be set to
         # the value in
-        functest = Functest(FUNCTEST_URL)
+        functest = Functest(FUNCTEST_URL, ssl_verify=False)
         self.assertEqual(functest.origin, FUNCTEST_URL)
         self.assertEqual(functest.tag, FUNCTEST_URL)
+        self.assertFalse(functest.ssl_verify)
 
         functest = Functest(FUNCTEST_URL, tag='')
         self.assertEqual(functest.origin, FUNCTEST_URL)
@@ -291,6 +294,23 @@ class TestFunctestClient(unittest.TestCase):
     into account that the body returned on each request might not
     match with the parameters from the request.
     """
+    def test_init(self):
+        """Test initialization"""
+
+        functest = FunctestClient(FUNCTEST_URL)
+        self.assertEqual(functest.base_url, FUNCTEST_URL)
+        self.assertEqual(functest.max_retries, 3)
+        self.assertIsNone(functest.archive)
+        self.assertFalse(functest.from_archive)
+        self.assertTrue(functest.ssl_verify)
+
+        functest = FunctestClient(FUNCTEST_URL, ssl_verify=False)
+        self.assertEqual(functest.base_url, FUNCTEST_URL)
+        self.assertEqual(functest.max_retries, 3)
+        self.assertIsNone(functest.archive)
+        self.assertFalse(functest.from_archive)
+        self.assertFalse(functest.ssl_verify)
+
     @httpretty.activate
     def test_repository(self):
         """Test repository API call"""
@@ -354,6 +374,13 @@ class TestFunctestCommand(unittest.TestCase):
         self.assertEqual(parsed_args.to_date,
                          datetime.datetime(2010, 1, 1, 0, 0, 0,
                                            tzinfo=dateutil.tz.tzutc()))
+        self.assertTrue(parsed_args.ssl_verify)
+
+        args = ['http://example.com', '--no-archive', '--no-ssl-verify']
+        parsed_args = parser.parse(*args)
+        self.assertEqual(parsed_args.url, 'http://example.com')
+        self.assertTrue(parsed_args.no_archive)
+        self.assertFalse(parsed_args.ssl_verify)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This code enhances the backend with the support
to disable SSL verification.

Tests have been added accordingly.

Backend version is now 0.6.0

Signed-off-by: Quan Zhou <quan@bitergia.com>